### PR TITLE
Fix for error with BuildCraft 6.3.2

### DIFF
--- a/src/main/java/info/inpureprojects/core/NEI/gtfoMicroblocks/ScriptObjects/BCObject.java
+++ b/src/main/java/info/inpureprojects/core/NEI/gtfoMicroblocks/ScriptObjects/BCObject.java
@@ -5,8 +5,8 @@ import info.inpureprojects.core.INpureCore;
 import info.inpureprojects.core.NEI.gtfoMicroblocks.NEIINpureConfig;
 import net.minecraft.item.ItemStack;
 
+import java.util.AbstractList;
 import java.util.Arrays;
-import java.util.LinkedList;
 
 /**
  * Created by den on 10/29/2014.
@@ -20,7 +20,7 @@ public class BCObject {
     public void obliterate_facades(int index) {
         NEIINpureConfig.logger.debug("obliterate_microblocks called (version in %s). Params: %s", this.getClass().getName(), String.valueOf(index));
         try {
-            LinkedList<ItemStack> facades = (LinkedList) Class.forName("buildcraft.transport.ItemFacade").getDeclaredField("allFacades").get(null);
+            AbstractList<ItemStack> facades = (AbstractList<ItemStack>)Class.forName("buildcraft.transport.ItemFacade").getDeclaredField("allFacades").get(null);
             API.setItemListEntries(facades.get(0).getItem(), Arrays.asList(new ItemStack[]{facades.get(index)}));
         } catch (Throwable t) {
             INpureCore.proxy.warning("Failed to hook bc!");
@@ -30,7 +30,7 @@ public class BCObject {
 
     public int getFacadesSize() {
         try {
-            LinkedList<ItemStack> facades = (LinkedList) Class.forName("buildcraft.transport.ItemFacade").getDeclaredField("allFacades").get(null);
+            AbstractList<ItemStack> facades = (AbstractList<ItemStack>)Class.forName("buildcraft.transport.ItemFacade").getDeclaredField("allFacades").get(null);
             NEIINpureConfig.logger.debug("getFacadesSize called. Returned: %s", String.valueOf(facades.size()));
             return facades.size();
         } catch (Throwable t) {


### PR DESCRIPTION
I locally applied this to your B7 release (3e1a6e74a1508ba1c0a2955876237e3de06bca57) and it worked well with BuildCraft 6.3.2 + 6.3.1.

I wasn't able to get the current build to work with my current mod pack due to NoClassDefFoundError: org/jruby/embed/jsr223/JRubyEngineFactory, but I assume that is a WIP.

Hope this helps, keep up the great work!